### PR TITLE
Bugfix/persist language change

### DIFF
--- a/app/Config.js
+++ b/app/Config.js
@@ -1,9 +1,6 @@
 /* eslint max-len: 0 */
 export const Config = {
   APP_NAME: 'Zenika Resume',
-  DEFAULT_USERPREF: {
-    locale: 'fr-FR'
-  },
   DEFAULT_METADATA: {
     name: 'Rory Williams',
     experience: '2 ans d\'expérience',

--- a/app/Document.js
+++ b/app/Document.js
@@ -1,7 +1,6 @@
 import {Record} from 'immutable';
 import {Config} from './Config';
 import uuid from 'uuid';
-import isEqual from 'lodash.isequal';
 
 export default class Document extends Record({
   uuid: uuid.v4(),
@@ -10,9 +9,7 @@ export default class Document extends Record({
   metadata: Config.DEFAULT_METADATA,
   last_modified: null, // defined by the server
   last_modified_locally: null,
-  userPref: Config.DEFAULT_USERPREF,
 }) {
-
   hasDefaultContent() {
     return Config.DEFAULT_CONTENT === this.content;
   }
@@ -29,11 +26,7 @@ export default class Document extends Record({
     return null === this.last_modified_locally;
   }
 
-  hasDefaultUserPref() {
-    return isEqual(Config.DEFAULT_USERPREF, this.userPref);
-  }
-
   isNew() {
-    return this.hasDefaultUserPref() && this.hasDefaultContent() && this.hasDefaultMetadata() && this.hasNeverBeenSync() && this.hasNoLocalChanges();
+    return this.hasDefaultContent() && this.hasDefaultMetadata() && this.hasNeverBeenSync() && this.hasNoLocalChanges();
   }
 }

--- a/app/Store.js
+++ b/app/Store.js
@@ -140,7 +140,6 @@ export default class Store {
         content: document.get('content'),
         metadata: document.get('metadata'),
         path: document.get('path'),
-        userPref: document.get('userPref'),
         last_modified: document.get('last_modified'),
         last_modified_locally: Date.now()
       }),

--- a/app/Store.js
+++ b/app/Store.js
@@ -185,7 +185,6 @@ export default class Store {
           metadata: res.body.metadata,
           path: res.body.path,
           last_modified: res.body.last_modified,
-          userPref: res.body.userPref
         });
 
         console.log(serverDoc.get('last_modified'), localDoc.get('last_modified'), localDoc.get('last_modified_locally'));
@@ -215,7 +214,6 @@ export default class Store {
                   path: serverDoc.get('path'),
                   metadata: serverDoc.get('metadata'),
                   last_modified: serverDoc.get('last_modified'),
-                  userPref: serverDoc.get('userPref')
                 });
 
                 this._setState(
@@ -331,7 +329,6 @@ export default class Store {
             content: encryptedContent,
             metadata: doc.get('metadata'),
             path: doc.get('path'),
-            userPref: doc.get('userPref'),
             last_modified: doc.get('last_modified'),
             last_modified_locally: doc.get('last_modified_locally')
           }).toJS()
@@ -369,7 +366,6 @@ export default class Store {
                     content: doc.get('content'),
                     metadata: doc.get('metadata'),
                     path: doc.get('path'),
-                    userPref: doc.get('userPref'),
                     last_modified: res.body.last_modified,
                     last_modified_locally: null
                   }),

--- a/app/Store.js
+++ b/app/Store.js
@@ -185,7 +185,8 @@ export default class Store {
           content: res.body.content,
           metadata: res.body.metadata,
           path: res.body.path,
-          last_modified: res.body.last_modified
+          last_modified: res.body.last_modified,
+          userPref: res.body.userPref
         });
 
         console.log(serverDoc.get('last_modified'), localDoc.get('last_modified'), localDoc.get('last_modified_locally'));
@@ -214,7 +215,8 @@ export default class Store {
                   content: decryptedContent,
                   path: serverDoc.get('path'),
                   metadata: serverDoc.get('metadata'),
-                  last_modified: serverDoc.get('last_modified')
+                  last_modified: serverDoc.get('last_modified'),
+                  userPref: serverDoc.get('userPref')
                 });
 
                 this._setState(
@@ -330,6 +332,7 @@ export default class Store {
             content: encryptedContent,
             metadata: doc.get('metadata'),
             path: doc.get('path'),
+            userPref: doc.get('userPref'),
             last_modified: doc.get('last_modified'),
             last_modified_locally: doc.get('last_modified_locally')
           }).toJS()
@@ -367,6 +370,7 @@ export default class Store {
                     content: doc.get('content'),
                     metadata: doc.get('metadata'),
                     path: doc.get('path'),
+                    userPref: doc.get('userPref'),
                     last_modified: res.body.last_modified,
                     last_modified_locally: null
                   }),

--- a/app/components/App.jsx
+++ b/app/components/App.jsx
@@ -11,7 +11,6 @@ import { Events } from '../Store';
 import Document from '../Document';
 import Translations from '../Translations';
 import debounce from 'lodash.debounce';
-import isEqual from 'lodash.isequal';
 
 import Editor from './Editor';
 import Footer from './Footer';
@@ -29,10 +28,8 @@ class App extends Component {
       loaded: false,
     };
     this.toggleLocale = this.toggleLocale.bind(this);
-    this.updateUserPref = this.updateUserPref.bind(this);
     this.updateContent = debounce(this.updateContent, 150);
     this.updateMetadata = debounce(this.updateMetadata, 150);
-    this.updateUserPref = debounce(this.updateUserPref, 150);
   }
 
   getChildContext() {
@@ -149,34 +146,26 @@ class App extends Component {
     }
   }
 
-  updateUserPref(newUserPref) {
-    const doc = this.state.document;
-    if (!isEqual(doc.userPref, newUserPref)) {
-      this.updateDocument(doc.metadata, doc.content, newUserPref);
-    }
-  }
-
   updateContent(newContent) {
     const doc = this.state.document;
     if (doc.content !== newContent) {
-      this.updateDocument(doc.metadata, newContent, doc.userPref);
+      this.updateDocument(doc.metadata, newContent);
     }
   }
 
   updateMetadata(newMetadata) {
     const doc = this.state.document;
     if (JSON.stringify(doc.metadata) !== JSON.stringify(newMetadata)) {
-      this.updateDocument(newMetadata, doc.content, doc.userPref);
+      this.updateDocument(newMetadata, doc.content);
     }
   }
 
-  updateDocument(metadata, content, userPref) {
+  updateDocument(metadata, content) {
     const doc = this.state.document;
     const newDoc = new Document({
       uuid: doc.get('uuid'),
       content,
       metadata,
-      userPref,
       path: doc.get('path'),
       last_modified: doc.get('last_modified'),
       last_modified_locally: doc.get('last_modified_locally'),

--- a/app/components/App.jsx
+++ b/app/components/App.jsx
@@ -25,6 +25,9 @@ class App extends Component {
     this.state = {
       document: new Document(),
       messages: new Immutable.List(),
+      userPref: {
+        locale: navigator.language === 'fr-FR' ? navigator.language : 'en-US'
+      },
       loaded: false,
     };
     this.toggleLocale = this.toggleLocale.bind(this);
@@ -189,14 +192,14 @@ class App extends Component {
   }
 
   toggleLocale(e) {
-    this.updateUserPref({
-      locale: e.target.value,
+    this.setState({
+      userPref: Object.assign({}, this.state.userPref, { locale: e.target.value })
     });
   }
 
   render() {
     let viewMode = '';
-    const locale = this.props.controller.store.state.document.userPref.locale;
+    const locale = this.state.userPref.locale;
     const messages = Translations[locale];
 
     if (!this.state.document.uuid) {
@@ -324,7 +327,7 @@ class App extends Component {
             version={this.props.version}
             metadata={this.state.document.get('metadata')}
             toggleLocale={this.toggleLocale}
-            currentLocale={this.props.controller.store.state.document.userPref.locale}
+            currentLocale={locale}
           />
         </div>
         </IntlProvider>


### PR DESCRIPTION
- remove user preference object from document
- create local userPref state and pass it as profs to footer component

fixes #23 

When syncing, the document would be reset with default user preference but it should not be the logic used. User preference on language should be a local state that should not be affected by syncing.