### PR TITLE
:pushpin: pin down npm version

### DIFF
--- a/package.json
+++ b/package.json
@@ -163,7 +163,8 @@
     "webpack-merge": "0.8.3"
   },
   "engines": {
-    "node": "5.7"
+    "node": "5.7",
+    "npm": "3.6.0"
   },
   "nyc": {
     "exclude": [


### PR DESCRIPTION
This is used by Heroku when deploying. Before this change, Heroku would
use Node 5.7 as specified in package.json but used a (seemingly)
incompatible npm 5.10.0 because of the presence of package-lock.json.

From Heroku build logs:
>-----> Installing binaries
>       engines.node (package.json):  5.7
>       engines.npm (package.json):   unspecified (use default)
>
>       Resolving node version 5.7...
>       Downloading and installing node 5.7.1...
>       Detected package-lock.json: defaulting npm to version 5.x.x
>       Bootstrapping npm 5.x.x (replacing 3.6.0)...
>       npm 5.10.0 installed

...

> -----> Building dependencies
>        Installing node modules (package.json + package-lock)
>        npm ERR! this is not a typed array.

...

> -----> Build failed