### PR TITLE
:bug: fix auth loop when invalid token present in local storage

### DIFF
--- a/app/components/App.jsx
+++ b/app/components/App.jsx
@@ -117,7 +117,7 @@ class App extends Component {
     });
 
     this.props.controller.on(Events.AUTHENTICATION_REQUIRED, () => {
-      auth.login();
+      auth.logout();
     });
 
     this.props.controller.on(`${Events.SYNCHRONIZE}, ${Events.CHANGE}`, (state) => {


### PR DESCRIPTION
What actually fixed the bug is using `logout` instead of `login` upon receiving a 401, because the former cleans up local values before trying to login again, which prevents the usage of local values when re-entering the application. I think it makes sense to clean up after a 401 because clearly that means that local values are no longer useful.

The `if (this.isAuthenticated())` is still useful is some cases but it cannot catch everything since the server and the client might not agree on what time it is.