### PR TITLE
💚 fix npm install

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,10 +13,15 @@ jobs:
       - run:
           name: Download UI dependencies
           command: |
+            # This brings global node_modules into the current file system layer so that
+            # npm can then be updated correctly. See https://github.com/npm/npm/issues/13306
+            # and https://blog.cloud66.com/using-node-with-docker/
+            # Then update npm to avoid this bug: https://github.com/npm/cli/issues/681
+            # NOTE: these 3 commands need to be run all at once
             mv /usr/local/lib/node_modules /usr/local/lib/node_modules.tmp \
               && mv /usr/local/lib/node_modules.tmp /usr/local/lib/node_modules \
-              && npm install -g npm@3.10.10
-            npm install
+              && npm install --quiet --global npm@3.10.10
+            npm install --quiet
       - save_cache:
           paths:
             - node_modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,17 @@
 FROM node:5.7 AS front
 
+# This brings global node_modules into the current file system layer so that
+# npm can then be updated correctly. See https://github.com/npm/npm/issues/13306
+# and https://blog.cloud66.com/using-node-with-docker/
+# Then update npm to avoid this bug: https://github.com/npm/cli/issues/681
+# NOTE: these 3 commands need to be run all at once
+RUN mv /usr/local/lib/node_modules /usr/local/lib/node_modules.tmp \
+  && mv /usr/local/lib/node_modules.tmp /usr/local/lib/node_modules \
+  && npm install --quiet --global npm@3.10.10
+
 WORKDIR /app
 COPY package.json .
 COPY package-lock.json .
-RUN mv /usr/local/lib/node_modules /usr/local/lib/node_modules.tmp \
-  && mv /usr/local/lib/node_modules.tmp /usr/local/lib/node_modules \
-  && npm install -g npm@3.10.10
 RUN npm install --quiet
 
 COPY app/ app/


### PR DESCRIPTION
Current npm install for front building is broken (see https://github.com/npm/cli/issues/681). Workaround is to update npm but then we get another bug (see https://github.com/npm/npm/issues/13306).

I found a quick fix here: https://blog.cloud66.com/using-node-with-docker/
