### PR TITLE
✨ add query param to view any version of a resume

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -131,14 +131,13 @@ function findByPath(req, res, path) {
       if (data.rows.length < 1) {
         findByUuid(req, res, path);
       } else {
-        data.uuid = "";
         res.status(200).json(buildDocumentFromQueryResult(data));
       }
     }
   );
 }
 
-function findByPathForVersionDate(req, res, path, version_date) {
+function findByPathForVersionDate(req, res, path, versionDate) {
   executeQueryWithCallback(
     `query resume($path: String_comparison_exp, $version_date: date_comparison_exp) {
       resume(where: {path: $path, version_date: $version_date}) {
@@ -150,14 +149,13 @@ function findByPathForVersionDate(req, res, path, version_date) {
       }
     }
     `,
-    { path: { _eq: path }, version_date: { _eq: version_date} },
+    { path: { _eq: path }, version_date: { _eq: versionDate} },
     req,
     res,
     function(data) {
       if (data.rows.length < 1) {
         res.status(404).json();
       } else {
-        data.uuid = "";
         res.status(200).json(buildDocumentFromQueryResult(data));
       }
     }

--- a/server/server.js
+++ b/server/server.js
@@ -155,7 +155,7 @@ function findByPathForVersionDate(req, res, path, version_date) {
     res,
     function(data) {
       if (data.rows.length < 1) {
-        findByUuid(req, res, path);
+        res.status(404).json();
       } else {
         data.uuid = "";
         res.status(200).json(buildDocumentFromQueryResult(data));
@@ -192,11 +192,11 @@ function findByUuid(req, res, uuid) {
 // API
 api.get("/documents/:uuid", jwtCheck, (req, res) => {
   const uuid = req.params.uuid;
-  const { version_date } = req.query;
-  if (!version_date) {
+  const { version_date :versionDate } = req.query;
+  if (!versionDate) {
     findByPath(req, res, uuid);
   } else {
-    findByPathForVersionDate(req, res, uuid, version_date);
+    findByPathForVersionDate(req, res, uuid, versionDate);
   }
 });
 


### PR DESCRIPTION
still working towards backing up resumes more easily. This PR aims to add the possibility to view older versions of a resume with query params. It works well

see #63 

<img width="1792" alt="image" src="https://user-images.githubusercontent.com/2174111/85011389-be3f8780-b161-11ea-93a3-3ecec476ecd6.png">

Right now it just displays a blank page if there is no resume corresponding to the version_date entered