### PR TITLE
🐛 fix incorrect resume retrieved when viewing

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -115,8 +115,14 @@ function buildDocumentFromQueryResult(data) {
 
 function findByPath(req, res, path) {
   executeQueryWithCallback(
-    `query resume($path: String_comparison_exp) {
-      resume: latest_resume(where: {path: $path}) {
+    `query resume($path: String) {
+      resume: latest_resume(
+        where: {
+          path: { _eq: $path }
+        }
+        order_by: { version_date: desc }
+        limit: 1
+      ) {
         content
         metadata
         path
@@ -124,7 +130,7 @@ function findByPath(req, res, path) {
         last_modified
       }
     }`,
-    { path: { _eq: path } },
+    { path },
     req,
     res,
     function(data) {


### PR DESCRIPTION
When viewing, the app uses finds the resume by its path. However there can be multiple resumes with the same path, and the app would take the first result, in database order, so the retrieved resume could be an incorrect one. This fixes the problem by making the app take the latest resume by version date for the given path.